### PR TITLE
fix `blank.lines.skip` argument in `fread`

### DIFF
--- a/TCRen_pipeline/run_TCRen.R
+++ b/TCRen_pipeline/run_TCRen.R
@@ -61,8 +61,7 @@ contacts.full <- rbind(
 )
 
 general_resmarkup <- fread(file.path(opt$out, "structures_annotation", "general.txt")) %>% 
-  merge(fread(file.path(opt$out, "structures_annotation", "resmarkup.txt")),
-        skip.blank.lines = T) %>% 
+  merge(fread(file.path(opt$out, "structures_annotation", "resmarkup.txt"), blank.lines.skip = T)) %>%
   group_by(pdb.id, chain.id, region.type) %>% 
   mutate(region.start = min(residue.index)) %>% 
   ungroup 

--- a/TCRen_pipeline/run_TCRen.Rmd
+++ b/TCRen_pipeline/run_TCRen.Rmd
@@ -80,8 +80,7 @@ Prepare annotation files
 ```{r}
 # Dataframe with assignment of chains
 general_resmarkup <- fread(file.path(out, "structures_annotation", "general.txt")) %>% 
-  merge(fread(file.path(out, "structures_annotation", "resmarkup.txt")),
-        skip.blank.lines = T) %>% 
+  merge(fread(file.path(out, "structures_annotation", "resmarkup.txt"), blank.lines.skip = T)) %>% 
   group_by(pdb.id, chain.id, region.type) %>% 
   mutate(region.start = min(residue.index)) %>% 
   ungroup 


### PR DESCRIPTION
This prevents the 
`Warning: Unknown argument 'skip.blank.lines' has been passed.` 
warning when running the script. 