### PR TITLE
S2: opt-in TCR framework regions FR1-3

### DIFF
--- a/src/tcren/cli.py
+++ b/src/tcren/cli.py
@@ -19,7 +19,7 @@ import typer
 
 from . import __version__
 from .annotation import classify_chains
-from .contactmap import ContactMap
+from .contactmap import TCR_REGIONS, ContactMap
 from .potential import Potential, derive_tcren, derive_tcren_loo, keskin, mj, tcren
 from .scoring import score_peptides
 from .structure import iter_structures, parse_structure
@@ -134,14 +134,19 @@ def contacts(
     out: Path = typer.Option("contacts.csv", "-o", "--out"),
     cutoff: float = typer.Option(5.0, "--cutoff"),
     interface: str = typer.Option("tcr_peptide", "--interface", help="tcr_peptide|tcr_mhc|peptide_mhc|all"),
+    regions: str = typer.Option("all", "--regions", help="TCR regions on the TCR side: all|cdr|cdr+fr (default: all)"),
     organism: str = typer.Option("human", "--organism"),
 ) -> None:
     """Compute and emit an annotated contact table."""
+    if regions not in TCR_REGIONS:
+        raise typer.BadParameter("--regions must be one of all|cdr|cdr+fr")
     frames = []
     for _pid, s in iter_structures(structures, importer=parse_structure):
         classify_chains(s, organism=organism)
         cm = ContactMap.from_structure(s, cutoff=cutoff)
-        frames.append(cm.contacts if interface == "all" else cm.interface(interface))
+        frames.append(
+            cm.contacts if interface == "all" else cm.interface(interface, tcr_regions=regions)
+        )
     pl.concat(frames).write_csv(str(out))
     typer.echo(f"wrote {out}")
 
@@ -290,17 +295,20 @@ def score(
     potential: str | None = typer.Option(None, "-p", "--potential", help="potential CSV (default: bundled TCRen)"),
     out: Path = typer.Option("candidate_epitopes_TCRen.csv", "-o", "--out"),
     interface: str = typer.Option("tcr_peptide", "--interface"),
+    regions: str = typer.Option("all", "--regions", help="TCR regions on the TCR side: all|cdr|cdr+fr (default: all)"),
     organism: str = typer.Option("human", "--organism"),
     cutoff: float = typer.Option(5.0, "--cutoff"),
 ) -> None:
     """Score candidate epitopes against input structures (end-to-end pipeline)."""
+    if regions not in TCR_REGIONS:
+        raise typer.BadParameter("--regions must be one of all|cdr|cdr+fr")
     pot = _load_potential(potential)
     cands = _read_candidates(candidates)
     frames = []
     for _pid, s in iter_structures(structures, importer=parse_structure):
         classify_chains(s, organism=organism)
         cm = ContactMap.from_structure(s, cutoff=cutoff)
-        frames.append(score_peptides(cm, cands, pot, interface=interface))
+        frames.append(score_peptides(cm, cands, pot, interface=interface, tcr_regions=regions))
     result = pl.concat(frames) if frames else pl.DataFrame()
     result.write_csv(str(out))
     typer.echo(f"The ranked list of candidate epitopes can be found in {out}")
@@ -317,6 +325,7 @@ def pipeline(
     tcr_peptide_potential: str = typer.Option(None, "--tcr-peptide-potential", help="potential for the TCR↔peptide interface: bundled name (tcren|mj|keskin) or CSV path (default: tcren)"),
     tcr_mhc_potential: str = typer.Option(None, "--tcr-mhc-potential", help="potential for the TCR↔MHC interface: bundled name or CSV path (default: mj)"),
     peptide_mhc_potential: str = typer.Option(None, "--peptide-mhc-potential", help="potential for the peptide↔MHC interface: bundled name or CSV path (default: mj)"),
+    regions: str = typer.Option("all", "--regions", help="TCR regions on the TCR side: all|cdr|cdr+fr (default: all)"),
 ) -> None:
     """Run the full pipeline and write per-interface energies for each structure.
 
@@ -328,6 +337,8 @@ def pipeline(
     """
     from .pipeline import run as run_pipeline, score_row
 
+    if regions not in TCR_REGIONS:
+        raise typer.BadParameter("--regions must be one of all|cdr|cdr+fr")
     potentials = {
         "tcr_peptide": tcr_peptide_potential,
         "tcr_mhc": tcr_mhc_potential,
@@ -337,7 +348,8 @@ def pipeline(
     for _pid, s in iter_structures(structures, importer=parse_structure):
         try:
             res = run_pipeline(s, organism=organism, superimpose=not no_superimpose,
-                               db_dir=db, cutoff=cutoff, potentials=potentials)
+                               db_dir=db, cutoff=cutoff,
+                               potentials=potentials, tcr_regions=regions)
             rows.append(score_row(res))
         except Exception as exc:  # noqa: BLE001 - keep the batch resilient
             rows.append({"pdb.id": s.pdb_id, "total": None,

--- a/src/tcren/contactmap.py
+++ b/src/tcren/contactmap.py
@@ -19,6 +19,15 @@ from .structure.model import MHC_TYPES, PEPTIDE_TYPE, RECEPTOR_TYPES, Structure
 
 Interface = Literal["tcr_peptide", "tcr_mhc", "peptide_mhc"]
 
+#: TCR region sets selectable on the ``from`` (TCR) side of an interface. ``"all"`` (no
+#: filter) is the default and reproduces the legacy behaviour byte-for-byte; ``"cdr"`` keeps
+#: only the three CDRs; ``"cdr+fr"`` adds the FR1–FR3 framework regions (FR4 excluded).
+TCR_REGIONS: dict[str, set[str] | None] = {
+    "cdr": {"CDR1", "CDR2", "CDR3"},
+    "cdr+fr": {"CDR1", "CDR2", "CDR3", "FR1", "FR2", "FR3"},
+    "all": None,
+}
+
 
 @dataclass(slots=True)
 class ContactMap:
@@ -51,22 +60,34 @@ class ContactMap:
             (pl.col("residue.index.to") - pl.col("region.start.to")).alias("pos.to"),
         )
 
-    def interface(self, which: Interface) -> pl.DataFrame:
+    def interface(self, which: Interface, tcr_regions: str = "all") -> pl.DataFrame:
         """Return the contacts of one interface with within-region positions.
 
         Args:
             which: ``"tcr_peptide"``, ``"tcr_mhc"`` or ``"peptide_mhc"``.
+            tcr_regions: which TCR regions to keep on the ``from`` (TCR) side —
+                ``"all"`` (default, no filter; legacy behaviour), ``"cdr"`` (CDR1–CDR3
+                only), or ``"cdr+fr"`` (CDR1–CDR3 plus FR1–FR3). Has no effect on
+                ``"peptide_mhc"`` (no TCR side).
 
         Returns:
             Filtered contacts with added ``pos.from``/``pos.to`` columns.
         """
+        if tcr_regions not in TCR_REGIONS:
+            raise ValueError(f"unknown tcr_regions {tcr_regions!r}")
         if which == "tcr_peptide":
-            return self._interface(RECEPTOR_TYPES, (PEPTIDE_TYPE,))
-        if which == "tcr_mhc":
-            return self._interface(RECEPTOR_TYPES, MHC_TYPES)
-        if which == "peptide_mhc":
+            sel = self._interface(RECEPTOR_TYPES, (PEPTIDE_TYPE,))
+        elif which == "tcr_mhc":
+            sel = self._interface(RECEPTOR_TYPES, MHC_TYPES)
+        elif which == "peptide_mhc":
             return self._interface((PEPTIDE_TYPE,), MHC_TYPES)
-        raise ValueError(f"unknown interface {which!r}")
+        else:
+            raise ValueError(f"unknown interface {which!r}")
+
+        keep = TCR_REGIONS[tcr_regions]
+        if keep is not None:  # TCR is on the 'from' side for these interfaces
+            sel = sel.filter(pl.col("region.type.from").is_in(list(keep)))
+        return sel
 
     def tcr_peptide(self) -> pl.DataFrame:
         """Convenience accessor for the TCR↔peptide interface."""

--- a/src/tcren/pipeline.py
+++ b/src/tcren/pipeline.py
@@ -102,6 +102,7 @@ def run(
     db_dir: str | Path | None = None,
     cutoff: float = 5.0,
     potentials: dict[str, str | Potential | None] | None = None,
+    tcr_regions: str = "all",
 ) -> PipelineResult:
     """Run the full pipeline on one structure (path or parsed :class:`Structure`).
 
@@ -116,6 +117,9 @@ def run(
             a bundled name (``"tcren"``/``"mj"``/``"keskin"``), a CSV path, or ``None``.
             ``None`` (or a missing entry) keeps the default family for that interface, so
             the default output is unchanged.
+        tcr_regions: which TCR regions to keep on the TCR side of the TCR-containing
+            interfaces (``"all"`` default = no filter = legacy behaviour; ``"cdr"`` or
+            ``"cdr+fr"`` to restrict).
 
     Returns:
         A :class:`PipelineResult` with the markup, contacts, per-interface scores and (if
@@ -135,7 +139,9 @@ def run(
     cm = ContactMap.from_structure(s, cutoff=cutoff)
     resolved = _resolve_potentials(potentials)
     scores = {
-        iface: _interface_energy(cm.interface(iface), resolved[iface])
+        iface: _interface_energy(
+            cm.interface(iface, tcr_regions=tcr_regions), resolved[iface]
+        )
         for iface in _INTERFACE_POTENTIAL
     }
     scores["total"] = sum(scores.values())

--- a/src/tcren/scoring.py
+++ b/src/tcren/scoring.py
@@ -30,6 +30,7 @@ def score_peptides(
     interface: Interface = "tcr_peptide",
     require_same_length: bool = True,
     substituted_side: str | None = None,
+    tcr_regions: str = "all",
 ) -> pl.DataFrame:
     """Score candidate peptides against a structure's contact map.
 
@@ -43,6 +44,8 @@ def score_peptides(
             map has no recorded peptide length.
         substituted_side: ``"to"`` or ``"from"`` — which contact side the candidate is
             threaded onto. Defaults to the peptide side of ``interface``.
+        tcr_regions: which TCR regions to keep on the TCR side (``"all"`` default = no
+            filter = legacy behaviour; ``"cdr"`` or ``"cdr+fr"`` to restrict).
 
     Returns:
         Columns ``complex.id``, ``peptide``, ``potential``, ``score`` sorted by
@@ -53,7 +56,7 @@ def score_peptides(
         raise ValueError(f"substituted_side must be 'to' or 'from', got {side!r}")
     fixed = "from" if side == "to" else "to"
 
-    iface = contact_map.interface(interface)
+    iface = contact_map.interface(interface, tcr_regions=tcr_regions)
     matrix, index = potential.as_matrix()
 
     pos = np.asarray(iface[f"pos.{side}"].to_list(), dtype=np.int64)

--- a/tests/unit/test_region_set.py
+++ b/tests/unit/test_region_set.py
@@ -1,0 +1,85 @@
+"""Opt-in TCR framework regions FR1-3 (S2): default 'all' unchanged; cdr/cdr+fr restrict."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from tcren.contactmap import TCR_REGIONS, ContactMap
+
+
+def test_region_sets_definition():
+    assert TCR_REGIONS["cdr"] == {"CDR1", "CDR2", "CDR3"}
+    assert TCR_REGIONS["cdr+fr"] == {"CDR1", "CDR2", "CDR3", "FR1", "FR2", "FR3"}
+    assert TCR_REGIONS["all"] is None  # 'all' = no filter = legacy behaviour
+
+
+def _toy_cm() -> ContactMap:
+    # Three TCR↔peptide contacts: CDR3, FR1, FR4. 'all' keeps all; 'cdr' keeps CDR3;
+    # 'cdr+fr' keeps CDR3 + FR1 (FR4 excluded).
+    contacts = pl.DataFrame(
+        {
+            "chain.type.from": ["TRA", "TRB", "TRB"],
+            "chain.type.to": ["PEPTIDE", "PEPTIDE", "PEPTIDE"],
+            "residue.aa.from": ["A", "L", "K"],
+            "residue.aa.to": ["G", "G", "G"],
+            "region.type.from": ["CDR3", "FR1", "FR4"],
+            "region.type.to": ["PEPTIDE", "PEPTIDE", "PEPTIDE"],
+            "residue.index.from": [10, 20, 30],
+            "residue.index.to": [0, 1, 2],
+            "region.start.from": [8, 18, 28],
+            "region.start.to": [0, 0, 0],
+            "pdb.id": ["toy", "toy", "toy"],
+        }
+    )
+    return ContactMap(pdb_id="toy", contacts=contacts, peptide_length=3)
+
+
+def test_toy_region_filter_counts_and_membership():
+    cm = _toy_cm()
+    n_all = cm.interface("tcr_peptide", tcr_regions="all").height
+    n_cdr = cm.interface("tcr_peptide", tcr_regions="cdr").height
+    n_cdrfr = cm.interface("tcr_peptide", tcr_regions="cdr+fr").height
+    assert n_cdr <= n_cdrfr <= n_all
+    assert n_cdr == 1 and n_cdrfr == 2 and n_all == 3  # CDR3 / +FR1 / +FR4
+    # Default 'all' is byte-identical to no argument (legacy behaviour).
+    assert cm.interface("tcr_peptide").equals(cm.interface("tcr_peptide", tcr_regions="all"))
+    cdrfr = cm.interface("tcr_peptide", tcr_regions="cdr+fr")
+    assert cdrfr.filter(pl.col("region.type.from").is_in(["FR1", "FR2", "FR3"])).height == 1
+
+
+def test_unknown_region_set_raises():
+    cm = _toy_cm()
+    with pytest.raises(ValueError):
+        cm.interface("tcr_peptide", tcr_regions="bogus")
+
+
+# --- Real TCR-pMHC asset: requires arda annotation. ---
+
+pytest.importorskip("arda")
+
+from tcren.annotation import classify_chains  # noqa: E402
+from tcren.structure import parse_structure  # noqa: E402
+
+# 5jhd's TCR↔peptide interface has CDR + a single FR contact, so cdr < cdr+fr == all.
+_FIXTURE = Path(__file__).resolve().parents[1] / "assets" / "pdb" / "5jhd.pdb"
+
+
+def test_real_asset_region_ordering_and_fr_membership():
+    s = parse_structure(_FIXTURE)
+    classify_chains(s, organism="human")
+    cm = ContactMap.from_structure(s)
+
+    n_all = cm.interface("tcr_peptide", tcr_regions="all").height
+    n_cdr = cm.interface("tcr_peptide", tcr_regions="cdr").height
+    n_cdrfr = cm.interface("tcr_peptide", tcr_regions="cdr+fr").height
+    assert n_cdr <= n_cdrfr <= n_all
+
+    cdrfr = cm.interface("tcr_peptide", tcr_regions="cdr+fr")
+    fr_rows = cdrfr.filter(pl.col("region.type.from").is_in(["FR1", "FR2", "FR3"]))
+    assert fr_rows.height > 0  # cdr+fr includes framework FR1-3 rows
+
+    # Default still byte-identical to no-filter on a real structure.
+    assert cm.interface("tcr_peptide").equals(cm.interface("tcr_peptide", tcr_regions="all"))


### PR DESCRIPTION
Opt-in FR1-3 region set; default 'all' byte-exact. Rebased on develop after S1.