### PR TITLE
S3: TCRen2 energy percentile-rank vs random pMHC background

### DIFF
--- a/src/tcren/__init__.py
+++ b/src/tcren/__init__.py
@@ -13,6 +13,7 @@ from .pipeline import run as run_pipeline
 from .potential import Potential, derive_tcren, derive_tcren_loo
 from .refine import refine_peptide, substitute_peptide
 from .scoring import score_peptides, score_structures
+from .scoring_rank import background_peptides, percentile_rank
 from .structure import Structure, import_structure, parse_structure
 
 __version__ = "0.1.0"
@@ -30,6 +31,8 @@ __all__ = [
     "ContactMap",
     "score_peptides",
     "score_structures",
+    "percentile_rank",
+    "background_peptides",
     "run_pipeline",
     "PipelineResult",
     "substitute_peptide",

--- a/src/tcren/cli.py
+++ b/src/tcren/cli.py
@@ -315,6 +315,59 @@ def score(
 
 
 @app.command()
+def rank(
+    structures: Path = typer.Option(..., "-s", "--structures", help="structure file, directory, or .tar.gz (.pdb/.cif/.pdb.gz/.cif.gz)"),
+    candidates: Path = typer.Option(None, "-c", "--candidates", help="peptides to rank; default: each structure's native peptide"),
+    potential: str | None = typer.Option(None, "-p", "--potential", help="potential CSV (default: bundled TCRen)"),
+    out: Path = typer.Option("rank.csv", "-o", "--out"),
+    interface: str = typer.Option("tcr_peptide", "--interface", help="tcr_peptide|tcr_mhc|peptide_mhc"),
+    regions: str = typer.Option("all", "--regions", help="TCR regions on the TCR side: all|cdr|cdr+fr (default: all)"),
+    background: int = typer.Option(1000, "--background", help="number of random background peptides"),
+    background_source: Path = typer.Option(None, "--background-source", help="FASTA/text of epitopes to sample the background from (default: uniform-random)"),
+    seed: int = typer.Option(0, "--seed"),
+    organism: str = typer.Option("human", "--organism"),
+    cutoff: float = typer.Option(5.0, "--cutoff"),
+) -> None:
+    """Percentile-rank peptides' TCRen energy against a random pMHC background.
+
+    For each structure, scores the supplied candidate peptides (or the structure's own
+    peptide when ``-c`` is omitted) together with ``--background`` random peptides of the
+    same length and reports ``rank_pct`` — the fraction of background scoring at least as
+    well (lower energy = better binder, so a small ``rank_pct`` means a strong binder).
+    """
+    if regions not in TCR_REGIONS:
+        raise typer.BadParameter("--regions must be one of all|cdr|cdr+fr")
+    from .scoring_rank import percentile_rank
+
+    from .structure.model import PEPTIDE_TYPE
+
+    pot = _load_potential(potential)
+    cands = _read_candidates(candidates) if candidates is not None else None
+    src = str(background_source) if background_source is not None else None
+    rows = []
+    for _pid, s in iter_structures(structures, importer=parse_structure):
+        classify_chains(s, organism=organism)
+        cm = ContactMap.from_structure(s, cutoff=cutoff)
+        if cands is not None:
+            peptides = cands
+        else:
+            native = next((c.sequence for c in s.chains if c.chain_type == PEPTIDE_TYPE), None)
+            if native is None:
+                raise typer.BadParameter(f"no peptide chain in {cm.pdb_id}; pass -c/--candidates")
+            peptides = [native]
+        for pep in peptides:
+            bg = None
+            if src is not None:
+                from .scoring_rank import background_peptides
+                bg = background_peptides(len(pep), n=background, seed=seed, source=src)
+            res = percentile_rank(cm, pep, pot, interface=interface, n_background=background,
+                                  seed=seed, tcr_regions=regions, background=bg)
+            rows.append({"complex.id": cm.pdb_id, **res})
+    pl.DataFrame(rows).write_csv(str(out))
+    typer.echo(f"wrote {out}")
+
+
+@app.command()
 def pipeline(
     structures: Path = typer.Option(..., "-s", "--structures", help="structure file, directory, or .tar.gz"),
     out: Path = typer.Option("pipeline_scores.csv", "-o", "--out", help="per-structure interface-score table"),

--- a/src/tcren/scoring_rank.py
+++ b/src/tcren/scoring_rank.py
@@ -1,0 +1,145 @@
+"""Percentile rank of a native peptide's energy against a random pMHC background.
+
+For a given structure, scores the native peptide together with a background of
+random (or epitope-sampled) peptides of the same length and reports where the
+native score falls in that distribution. Lower TCRen energy = better binder, so a
+small ``rank_pct`` means the native peptide scores at least as well as only a small
+fraction of the background.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Iterable
+from pathlib import Path
+
+from .contactmap import ContactMap, Interface
+from .potential import Potential
+from .scoring import score_peptides
+
+#: The 20 standard amino acids, used to draw uniform-random background peptides.
+_AMINO_ACIDS = "ACDEFGHIKLMNPQRSTVWY"
+
+
+def _read_source(source: str | Path) -> list[str]:
+    """Read epitope sequences from a FASTA or plain-text file (one per line)."""
+    seqs: list[str] = []
+    cur: list[str] = []
+    for line in Path(source).read_text().splitlines():
+        line = line.strip()
+        if not line or line.lower() == "peptide":
+            continue
+        if line.startswith(">"):
+            if cur:
+                seqs.append("".join(cur))
+                cur = []
+            continue
+        cur.append(line)
+    if cur:
+        seqs.append("".join(cur))
+    return seqs
+
+
+def background_peptides(
+    length: int,
+    n: int = 1000,
+    seed: int = 0,
+    source: str | None = None,
+) -> list[str]:
+    """Build a background set of ``n`` peptides of the given length.
+
+    Args:
+        length: Required peptide length.
+        n: Number of background peptides to return.
+        seed: Random seed for reproducibility.
+        source: Optional FASTA/text file of epitopes. When given, peptides of the
+            requested length are sampled from it (with replacement); each sampled
+            sequence is also position-permuted so the background is a shuffled-epitope
+            distribution rather than a verbatim copy. When ``None``, peptides are
+            drawn uniformly at random over the 20 amino acids.
+
+    Returns:
+        A list of ``n`` upper-case peptide strings, each of length ``length``.
+    """
+    rng = random.Random(seed)
+    if source is not None:
+        pool = [s for s in _read_source(source) if len(s) == length]
+        if not pool:
+            raise ValueError(f"no length-{length} epitopes found in {source!r}")
+        out = []
+        for _ in range(n):
+            chars = list(rng.choice(pool))
+            rng.shuffle(chars)
+            out.append("".join(chars))
+        return out
+    return ["".join(rng.choice(_AMINO_ACIDS) for _ in range(length)) for _ in range(n)]
+
+
+def percentile_rank(
+    contact_map: ContactMap,
+    peptide: str,
+    potential: Potential,
+    *,
+    interface: Interface = "tcr_peptide",
+    n_background: int = 1000,
+    seed: int = 0,
+    tcr_regions: str = "all",
+    background: Iterable[str] | None = None,
+) -> dict:
+    """Percentile rank of a peptide's energy against a random pMHC background.
+
+    Scores ``peptide`` together with a background set (supplied or generated) and
+    returns the fraction of background peptides whose score is ``<=`` the native
+    score. Because lower TCRen energy means a better binder, a smaller ``rank_pct``
+    indicates the native peptide is among the strongest binders.
+
+    Args:
+        contact_map: The structure's contact map.
+        peptide: The native peptide to rank.
+        potential: Pairwise potential to score with.
+        interface: Which interface to score over (default ``"tcr_peptide"``).
+        n_background: Size of the generated background (ignored if ``background`` is
+            given).
+        seed: Random seed for background generation.
+        tcr_regions: Which TCR regions to keep on the TCR side (``"all"`` default,
+            ``"cdr"`` or ``"cdr+fr"``); passed through to ``score_peptides``.
+        background: Explicit background peptides; when ``None`` a uniform-random
+            background of length ``len(peptide)`` is generated.
+
+    Returns:
+        Mapping with keys ``peptide``, ``score`` (native energy), ``rank_pct``
+        (fraction of background with score ``<=`` native), and ``n_background``.
+    """
+    if background is None:
+        bg = background_peptides(len(peptide), n=n_background, seed=seed)
+    else:
+        bg = list(background)
+
+    scored = score_peptides(
+        contact_map, [peptide] + bg, potential, interface=interface, tcr_regions=tcr_regions
+    )
+    by_peptide = dict(zip(scored["peptide"], scored["score"]))
+    if peptide not in by_peptide:
+        raise ValueError(
+            f"native peptide {peptide!r} was not scored "
+            "(length mismatch with the structure's peptide?)"
+        )
+    native_score = by_peptide[peptide]
+
+    # Background scores, looked up per generated peptide; entries dropped by the
+    # length filter in score_peptides (e.g. a wrong-length supplied background) are
+    # excluded from the denominator. A background peptide equal to the native maps
+    # to the same score and counts as a tie (score <= native).
+    bg_scores = [by_peptide[p] for p in bg if p in by_peptide]
+    n_bg = len(bg_scores)
+    if n_bg == 0:
+        raise ValueError("no background peptides were scored")
+    n_le = sum(1 for s in bg_scores if s <= native_score)
+    rank_pct = n_le / n_bg
+
+    return {
+        "peptide": peptide,
+        "score": native_score,
+        "rank_pct": rank_pct,
+        "n_background": n_bg,
+    }

--- a/tests/unit/test_scoring_rank.py
+++ b/tests/unit/test_scoring_rank.py
@@ -1,0 +1,122 @@
+"""Unit tests for the percentile-rank engine (S3).
+
+This is a new method, so there is no external oracle CSV. The checks are
+determinism (same seed => identical result) plus analytic properties on a tiny
+hand-built contact map / potential.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from tcren.contactmap import ContactMap
+from tcren.potential import Potential
+from tcren.scoring_rank import background_peptides, percentile_rank
+
+_AMINO_ACIDS = "ACDEFGHIKLMNPQRSTVWY"
+
+
+def _toy_potential() -> Potential:
+    # 3-letter alphabet with distinct, hand-checkable values (mirrors test_scoring).
+    vals = {("A", "A"): 1.0, ("A", "K"): -2.0, ("L", "A"): 0.5, ("L", "K"): 3.0,
+            ("A", "G"): 0.1, ("L", "G"): 0.2}
+    rows = [{"residue.aa.from": fr, "residue.aa.to": to, "value": v}
+            for (fr, to), v in vals.items()]
+    return Potential(name="toy", matrix=pl.DataFrame(rows), alphabet=("A", "L", "K", "G"))
+
+
+def _toy_contact_map() -> ContactMap:
+    # TCR 'A' contacts peptide pos 0; TCR 'L' contacts peptide pos 2.
+    contacts = pl.DataFrame(
+        {
+            "chain.type.from": ["TRA", "TRB"],
+            "chain.type.to": ["PEPTIDE", "PEPTIDE"],
+            "residue.aa.from": ["A", "L"],
+            "residue.aa.to": ["G", "G"],
+            "region.type.from": ["CDR3", "CDR3"],
+            "residue.index.from": [10, 20],
+            "residue.index.to": [0, 2],
+            "region.start.from": [8, 18],
+            "region.start.to": [0, 0],
+            "pdb.id": ["toy", "toy"],
+        }
+    )
+    return ContactMap(pdb_id="toy", contacts=contacts, peptide_length=3)
+
+
+# --- background_peptides --------------------------------------------------------------
+
+def test_background_determinism():
+    a = background_peptides(9, n=50, seed=42)
+    b = background_peptides(9, n=50, seed=42)
+    assert a == b
+    assert background_peptides(9, n=50, seed=43) != a
+
+
+def test_background_shape_and_alphabet():
+    bg = background_peptides(9, n=100, seed=0)
+    assert len(bg) == 100
+    assert all(len(p) == 9 for p in bg)
+    assert set("".join(bg)) <= set(_AMINO_ACIDS)
+
+
+def test_background_from_source(tmp_path):
+    fasta = tmp_path / "epi.fasta"
+    fasta.write_text(">e1\nAGKAGKAGK\n>e2\nKKAAGGLLM\n>short\nAGK\n")
+    bg = background_peptides(9, n=20, seed=1, source=str(fasta))
+    assert len(bg) == 20
+    assert all(len(p) == 9 for p in bg)
+    # permutations of length-9 epitopes only; the length-3 entry is excluded.
+    pool = {"AGKAGKAGK", "KKAAGGLLM"}
+    assert all(sorted(p) in [sorted(s) for s in pool] for p in bg)
+
+
+# --- percentile_rank ------------------------------------------------------------------
+
+def test_rank_determinism():
+    cm, pot = _toy_contact_map(), _toy_potential()
+    r1 = percentile_rank(cm, "AGK", pot, n_background=200, seed=7)
+    r2 = percentile_rank(cm, "AGK", pot, n_background=200, seed=7)
+    assert r1 == r2
+
+
+def test_rank_properties():
+    cm, pot = _toy_contact_map(), _toy_potential()
+    res = percentile_rank(cm, "AGK", pot, n_background=200, seed=0)
+    assert set(res) == {"peptide", "score", "rank_pct", "n_background"}
+    assert res["peptide"] == "AGK"
+    assert 0.0 <= res["rank_pct"] <= 1.0
+    assert res["n_background"] == 200
+    # native "AGK": pos0 'A' x TCR 'A' = (A,A)=1.0 ; pos2 'K' x TCR 'L' = (L,K)=3.0 -> 4.0
+    assert res["score"] == pytest.approx(4.0)
+
+
+def test_rank_analytic_with_explicit_background():
+    cm, pot = _toy_contact_map(), _toy_potential()
+    # Native "AGK" -> 4.0. Build a hand-chosen background:
+    #   "AGA": (A,A)=1.0 + (L,A)=0.5 = 1.5   (< 4.0  -> counts)
+    #   "AGK": 4.0                            (== 4.0 -> tie, counts)
+    #   "LGK": (A,L) missing -> dropped; (L,K)=3.0 -> 3.0  (< 4.0 -> counts)
+    #          ('L' at pos0 pairs TCR 'A'; (A,L) absent from potential, contributes 0)
+    # All three have score <= 4.0 => rank_pct == 1.0
+    bg = ["AGA", "AGK", "LGK"]
+    res = percentile_rank(cm, "AGK", pot, background=bg)
+    assert res["n_background"] == 3
+    assert res["rank_pct"] == pytest.approx(1.0)
+
+    # A background strictly worse than native gives rank_pct 0.
+    # "GGG": pos0 'G' x TCR 'A' = (A,G)=0.1 ; pos2 'G' x TCR 'L' = (L,G)=0.2 -> 0.3 (better!)
+    # Use a peptide that scores worse: need score > 4.0. "AGK" axis only reaches 4.0 max here,
+    # so instead rank the weakest binder against a strong-only background.
+    res2 = percentile_rank(cm, "GGG", pot, background=["AGK"])
+    # native "GGG" -> 0.3 ; background "AGK" -> 4.0 (> 0.3, not <=) => rank_pct 0
+    assert res2["score"] == pytest.approx(0.3)
+    assert res2["rank_pct"] == pytest.approx(0.0)
+
+
+def test_rank_native_missing_raises():
+    cm, pot = _toy_contact_map(), _toy_potential()
+    with pytest.raises(ValueError):
+        # wrong length -> dropped by score_peptides' length filter
+        percentile_rank(cm, "AGKK", pot, background=["AGK"])


### PR DESCRIPTION
Adds `tcren rank`: percentile-ranks candidate peptides' TCRen energy against a random pMHC background.

- `src/tcren/scoring_rank.py`: `percentile_rank`, `background_peptides`
- `tcren rank` CLI command (interface/regions/background/seed options)
- Exports added to `tcren.__init__`
- Unit tests in `tests/unit/test_scoring_rank.py`

Off develop, single commit `ee27572`. Regression oracle untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)