### PR TITLE
S4: TCRen2 ΔΔG alanine scan + neoantigen

### DIFF
--- a/src/tcren/__init__.py
+++ b/src/tcren/__init__.py
@@ -8,6 +8,7 @@ scoring are added in later milestones.
 from . import potential
 from .contactmap import ContactMap
 from .contacts import all_atom_contacts, ca_distance_matrix
+from .ddg import alanine_scan, ddg, neoantigen_ddg
 from .pipeline import PipelineResult
 from .pipeline import run as run_pipeline
 from .potential import Potential, derive_tcren, derive_tcren_loo
@@ -33,6 +34,9 @@ __all__ = [
     "score_structures",
     "percentile_rank",
     "background_peptides",
+    "ddg",
+    "alanine_scan",
+    "neoantigen_ddg",
     "run_pipeline",
     "PipelineResult",
     "substitute_peptide",

--- a/src/tcren/cli.py
+++ b/src/tcren/cli.py
@@ -314,6 +314,45 @@ def score(
     typer.echo(f"The ranked list of candidate epitopes can be found in {out}")
 
 
+@app.command("ddg")
+def ddg_cmd(
+    structures: Path = typer.Option(..., "-s", "--structures", help="structure file, directory, or .tar.gz (.pdb/.cif/.pdb.gz/.cif.gz)"),
+    native: str = typer.Option(..., "--native", help="native peptide sequence"),
+    alanine_scan: bool = typer.Option(False, "--alanine-scan", help="ΔΔG of every position mutated to alanine"),
+    mutant: list[str] = typer.Option(None, "--mutant", help="mutant peptide(s); repeat for several (neoantigen mode)"),
+    potential: str | None = typer.Option(None, "-p", "--potential", help="potential CSV (default: bundled TCRen)"),
+    out: Path = typer.Option("ddg.csv", "-o", "--out"),
+    interface: str = typer.Option("tcr_peptide", "--interface", help="tcr_peptide|tcr_mhc|peptide_mhc"),
+    regions: str = typer.Option("all", "--regions", help="TCR regions on the TCR side: all|cdr|cdr+fr (default: all)"),
+    organism: str = typer.Option("human", "--organism"),
+    cutoff: float = typer.Option(5.0, "--cutoff"),
+) -> None:
+    """ΔΔG of peptide mutations (fast virtual-matrix path; no atoms move).
+
+    Re-scores the mutant sequence on the native contact map; ``ddG = E(native) - E(mutant)``
+    (positive => destabilising). Use ``--alanine-scan`` for a per-position scan, or one or more
+    ``--mutant`` for specific neoantigen substitutions.
+    """
+    if regions not in TCR_REGIONS:
+        raise typer.BadParameter("--regions must be one of all|cdr|cdr+fr")
+    if alanine_scan == bool(mutant):
+        raise typer.BadParameter("pass exactly one of --alanine-scan or --mutant")
+    from .ddg import alanine_scan as run_scan, neoantigen_ddg
+
+    pot = _load_potential(potential)
+    frames = []
+    for _pid, s in iter_structures(structures, importer=parse_structure):
+        classify_chains(s, organism=organism)
+        cm = ContactMap.from_structure(s, cutoff=cutoff)
+        if alanine_scan:
+            df = run_scan(cm, native, pot, interface=interface, tcr_regions=regions)
+        else:
+            df = neoantigen_ddg(cm, native, mutant, pot, interface=interface, tcr_regions=regions)
+        frames.append(df.with_columns(pl.lit(cm.pdb_id).alias("complex.id")))
+    pl.concat(frames).write_csv(str(out))
+    typer.echo(f"wrote {out}")
+
+
 @app.command()
 def rank(
     structures: Path = typer.Option(..., "-s", "--structures", help="structure file, directory, or .tar.gz (.pdb/.cif/.pdb.gz/.cif.gz)"),

--- a/src/tcren/ddg.py
+++ b/src/tcren/ddg.py
@@ -1,0 +1,128 @@
+"""Fast ΔΔG of peptide point mutations (virtual-matrix path).
+
+Implements the paper's fast ΔΔG: no atoms move and no re-docking is performed.
+A mutation's effect is read straight off the substitution potential by re-scoring
+the mutant sequence on the *same* contact map. ``ddg = E(native) - E(mutant)`` so a
+positive value flags a destabilising mutation (the mutant binds less favourably,
+i.e. has higher energy).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import polars as pl
+
+from .contactmap import ContactMap, Interface
+from .potential import Potential
+from .scoring import score_peptides
+
+
+def _score_one(
+    contact_map: ContactMap,
+    peptide: str,
+    potential: Potential,
+    interface: Interface,
+    tcr_regions: str,
+) -> float:
+    """Score a single peptide and return its scalar energy."""
+    res = score_peptides(
+        contact_map, [peptide], potential, interface=interface, tcr_regions=tcr_regions
+    )
+    if res.height == 0:
+        raise ValueError(
+            f"peptide {peptide!r} was not scored "
+            "(length mismatch with the structure's peptide?)"
+        )
+    return float(res["score"][0])
+
+
+def ddg(
+    contact_map: ContactMap,
+    native: str,
+    mutant: str,
+    potential: Potential,
+    *,
+    interface: Interface = "tcr_peptide",
+    tcr_regions: str = "all",
+) -> float:
+    """ΔΔG of a peptide mutation as ``E(native) - E(mutant)``.
+
+    Args:
+        contact_map: The structure's contact map.
+        native: Native peptide sequence.
+        mutant: Mutant peptide sequence (same length as ``native``).
+        potential: Pairwise potential to score with.
+        interface: Which interface to score over (default ``"tcr_peptide"``).
+        tcr_regions: Which TCR regions to keep on the TCR side (passed through to
+            ``score_peptides``).
+
+    Returns:
+        ``E(native) - E(mutant)``; positive means the mutation is destabilising.
+    """
+    e_native = _score_one(contact_map, native, potential, interface, tcr_regions)
+    e_mutant = _score_one(contact_map, mutant, potential, interface, tcr_regions)
+    return e_native - e_mutant
+
+
+def alanine_scan(
+    contact_map: ContactMap,
+    native: str,
+    potential: Potential,
+    *,
+    interface: Interface = "tcr_peptide",
+    tcr_regions: str = "all",
+) -> pl.DataFrame:
+    """Alanine scan of the native peptide.
+
+    Mutates each position of ``native`` to alanine in turn and reports the ΔΔG of
+    that single substitution. One row per peptide position.
+
+    Args:
+        contact_map: The structure's contact map.
+        native: Native peptide sequence.
+        potential: Pairwise potential to score with.
+        interface: Which interface to score over (default ``"tcr_peptide"``).
+        tcr_regions: Which TCR regions to keep on the TCR side.
+
+    Returns:
+        Columns ``pos`` (0-based), ``wt_aa`` (native residue at that position) and
+        ``ddG`` (``E(native) - E(Ala@pos)``). Positions without TCR contacts yield
+        ``ddG == 0.0``.
+    """
+    e_native = _score_one(contact_map, native, potential, interface, tcr_regions)
+    rows = []
+    for pos, wt in enumerate(native):
+        mutant = native[:pos] + "A" + native[pos + 1 :]
+        e_mut = _score_one(contact_map, mutant, potential, interface, tcr_regions)
+        rows.append({"pos": pos, "wt_aa": wt, "ddG": e_native - e_mut})
+    return pl.DataFrame(rows, schema={"pos": pl.Int64, "wt_aa": pl.Utf8, "ddG": pl.Float64})
+
+
+def neoantigen_ddg(
+    contact_map: ContactMap,
+    native: str,
+    mutants: Iterable[str],
+    potential: Potential,
+    **kw,
+) -> pl.DataFrame:
+    """ΔΔG of candidate neoantigen mutants relative to a native peptide.
+
+    Args:
+        contact_map: The structure's contact map.
+        native: Native peptide sequence.
+        mutants: Candidate mutant peptides (each the same length as ``native``).
+        potential: Pairwise potential to score with.
+        **kw: Forwarded to :func:`ddg` (``interface``, ``tcr_regions``).
+
+    Returns:
+        Columns ``native``, ``mutant`` and ``ddG`` (``E(native) - E(mutant)``;
+        positive means the mutation is destabilising), one row per mutant.
+    """
+    rows = [
+        {"native": native, "mutant": m, "ddG": ddg(contact_map, native, m, potential, **kw)}
+        for m in mutants
+    ]
+    return pl.DataFrame(
+        rows, schema={"native": pl.Utf8, "mutant": pl.Utf8, "ddG": pl.Float64}
+    )

--- a/tests/unit/test_ddg.py
+++ b/tests/unit/test_ddg.py
@@ -1,0 +1,102 @@
+"""Unit tests for the fast ΔΔG engine (S4).
+
+Uses the same tiny hand-built contact map / potential as the scoring tests so the
+energies are analytically checkable. No external oracle CSV (new method); the
+checks are the ΔΔG identities and per-position structure.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from tcren.contactmap import ContactMap
+from tcren.ddg import alanine_scan, ddg, neoantigen_ddg
+from tcren.potential import Potential
+from tcren.scoring import score_peptides
+
+
+def _toy_potential() -> Potential:
+    vals = {("A", "A"): 1.0, ("A", "K"): -2.0, ("L", "A"): 0.5, ("L", "K"): 3.0,
+            ("A", "G"): 0.1, ("L", "G"): 0.2}
+    rows = [{"residue.aa.from": fr, "residue.aa.to": to, "value": v}
+            for (fr, to), v in vals.items()]
+    return Potential(name="toy", matrix=pl.DataFrame(rows), alphabet=("A", "L", "K", "G"))
+
+
+def _toy_contact_map() -> ContactMap:
+    # TCR 'A' contacts peptide pos 0; TCR 'L' contacts peptide pos 2.
+    contacts = pl.DataFrame(
+        {
+            "chain.type.from": ["TRA", "TRB"],
+            "chain.type.to": ["PEPTIDE", "PEPTIDE"],
+            "residue.aa.from": ["A", "L"],
+            "residue.aa.to": ["G", "G"],
+            "region.type.from": ["CDR3", "CDR3"],
+            "residue.index.from": [10, 20],
+            "residue.index.to": [0, 2],
+            "region.start.from": [8, 18],
+            "region.start.to": [0, 0],
+            "pdb.id": ["toy", "toy"],
+        }
+    )
+    return ContactMap(pdb_id="toy", contacts=contacts, peptide_length=3)
+
+
+def test_ddg_native_vs_native_is_zero():
+    cm, pot = _toy_contact_map(), _toy_potential()
+    assert ddg(cm, "AGK", "AGK", pot) == 0.0
+
+
+def test_ddg_matches_independent_two_calls():
+    cm, pot = _toy_contact_map(), _toy_potential()
+    native, mutant = "AGK", "AGA"
+    e_native = float(score_peptides(cm, [native], pot)["score"][0])
+    e_mutant = float(score_peptides(cm, [mutant], pot)["score"][0])
+    assert ddg(cm, native, mutant, pot) == pytest.approx(e_native - e_mutant)
+
+
+def test_ddg_sign_and_value():
+    cm, pot = _toy_contact_map(), _toy_potential()
+    # native "AGK": (A,A)=1.0 + (L,K)=3.0 = 4.0
+    # mutant "AGA": (A,A)=1.0 + (L,A)=0.5 = 1.5  -> ddG = 4.0 - 1.5 = 2.5 (destabilising)
+    assert ddg(cm, "AGK", "AGA", pot) == pytest.approx(2.5)
+
+
+def test_alanine_scan_one_row_per_position():
+    cm, pot = _toy_contact_map(), _toy_potential()
+    native = "AGK"
+    scan = alanine_scan(cm, native, pot)
+    assert scan.columns == ["pos", "wt_aa", "ddG"]
+    assert scan.height == len(native)
+    assert scan["pos"].to_list() == [0, 1, 2]
+    # wt_aa column reproduces the native peptide.
+    assert scan["wt_aa"].to_list() == list(native)
+    # pos0 is already 'A' -> mutating to Ala is a no-op -> ddG 0.
+    assert scan.filter(pl.col("pos") == 0)["ddG"][0] == pytest.approx(0.0)
+    # pos1 'G' has no TCR contact -> no-op -> ddG 0.
+    assert scan.filter(pl.col("pos") == 1)["ddG"][0] == pytest.approx(0.0)
+    # pos2 'K'->'A': contributes (L,K)=3.0 native vs (L,A)=0.5 -> ddG = 2.5.
+    assert scan.filter(pl.col("pos") == 2)["ddG"][0] == pytest.approx(2.5)
+
+
+def test_alanine_scan_position_matches_independent_ddg():
+    cm, pot = _toy_contact_map(), _toy_potential()
+    native = "AGK"
+    scan = alanine_scan(cm, native, pot)
+    for pos in range(len(native)):
+        mutant = native[:pos] + "A" + native[pos + 1:]
+        expected = ddg(cm, native, mutant, pot)
+        assert scan.filter(pl.col("pos") == pos)["ddG"][0] == pytest.approx(expected)
+
+
+def test_neoantigen_ddg():
+    cm, pot = _toy_contact_map(), _toy_potential()
+    native = "AGK"
+    mutants = ["AGA", "AGK"]
+    df = neoantigen_ddg(cm, native, mutants, pot)
+    assert df.columns == ["native", "mutant", "ddG"]
+    assert df["native"].to_list() == [native, native]
+    assert df["mutant"].to_list() == mutants
+    assert df.filter(pl.col("mutant") == "AGA")["ddG"][0] == pytest.approx(2.5)
+    assert df.filter(pl.col("mutant") == "AGK")["ddG"][0] == pytest.approx(0.0)


### PR DESCRIPTION
Adds `tcren ddg`: ΔΔG of peptide mutations via the fast virtual-matrix path (no atoms move). Re-scores the mutant on the native contact map; `ddG = E(native) - E(mutant)` (positive => destabilising).

- `src/tcren/ddg.py`: `ddg`, `alanine_scan`, `neoantigen_ddg`
- `tcren ddg` CLI command (`--alanine-scan` per-position scan, or one/more `--mutant` for neoantigens)
- Exports added to `tcren.__init__`
- Unit tests in `tests/unit/test_ddg.py`

Rebased onto develop after S3 (#9). `cli.py`/`__init__.py` resolved by union — both `rank` and `ddg` commands and all exports retained. Regression oracle untouched; `pytest -m 'not slow'` green (158 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)