### PR TITLE
S5: oracle facade — summarize_structure composing S1-S4

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ and scores candidate epitopes.
    :caption: Contents
 
    getting-started
+   oracle
    performance
    modules
 

--- a/docs/oracle.rst
+++ b/docs/oracle.rst
@@ -1,0 +1,93 @@
+Structure summary (oracle)
+==========================
+
+:func:`tcren.summarize_structure` is the one-call entry point the paper notebooks use:
+it takes a single TCR–peptide–MHC structure and returns a bundle of ready-to-tabulate
+frames by composing the pipeline (S1+S2), the percentile rank (S3) and the alanine scan
+(S4). Nothing is re-derived — the facade only orchestrates those functions, so its
+``scores`` frame is byte-identical to :func:`tcren.pipeline.run`'s scores.
+
+API
+---
+
+The full signature and argument reference live with the module autodoc:
+:func:`tcren.oracle.summarize_structure` (re-exported as ``tcren.summarize_structure``).
+
+The five returned frames:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 14 16 70
+
+   * - Key
+     - Source
+     - Contents
+   * - ``scores``
+     - S1+S2 (``run``)
+     - One row of per-interface energies (``tcr_peptide``, ``tcr_mhc``, ``peptide_mhc``,
+       ``total``) and ``rmsd`` when ``superimpose=True``.
+   * - ``rank``
+     - S3 (``percentile_rank``)
+     - One row: the native peptide's energy and its ``rank_pct`` against a random
+       pMHC background.
+   * - ``ddg``
+     - S4 (``alanine_scan``)
+     - Per-position alanine scan (``pos``/``wt_aa``/``ddG``); empty unless ``alanine=True``.
+   * - ``markup``
+     - S1+S2 (``run``)
+     - The per-residue region-markup table.
+   * - ``contacts``
+     - S1+S2 (``run``)
+     - The annotated residue-contact table.
+
+Example
+-------
+
+The script below turns a PDB into the five summary CSVs (default: the bundled ``1ao7``
+fixture):
+
+.. literalinclude:: ../scripts/summarize_structure_example.py
+   :language: python
+   :caption: scripts/summarize_structure_example.py
+
+Run it with the activated ``tcren`` environment:
+
+.. code-block:: console
+
+   $ python scripts/summarize_structure_example.py complex.pdb summary/
+   scores       1 x 6  -> summary/scores.csv
+   rank         1 x 5  -> summary/rank.csv
+   ddg          9 x 3  -> summary/ddg.csv
+   markup     605 x 7  -> summary/markup.csv
+   contacts   512 x 18 -> summary/contacts.csv
+
+Command line
+------------
+
+The ``rank`` and ``ddg`` frames are also available as standalone CLI subcommands.
+
+``tcren rank`` — percentile-rank a peptide's TCRen energy against a random pMHC
+background. With no ``-c/--candidates`` it ranks each structure's own native peptide:
+
+.. code-block:: console
+
+   $ tcren rank -s complex.pdb -o rank.csv
+   $ tcren rank -s complex.pdb -c candidates.txt --background 5000 --seed 1 -o rank.csv
+
+The output carries ``complex.id``, ``peptide``, ``score`` (native energy), ``rank_pct``
+(fraction of background scoring at least as well — lower energy is a better binder, so a
+small ``rank_pct`` flags a strong binder) and ``n_background``. ``--background-source``
+points at a FASTA/text file of epitopes to sample the background from instead of drawing
+it uniformly at random.
+
+``tcren ddg`` — fast ΔΔG of peptide mutations (virtual-matrix path; no atoms move).
+``ddG = E(native) - E(mutant)``, so a positive value is destabilising:
+
+.. code-block:: console
+
+   $ tcren ddg -s complex.pdb --native LLFGYPVYV --alanine-scan -o ddg.csv
+   $ tcren ddg -s complex.pdb --native LLFGYPVYV --mutant LLFGYPVYA --mutant LLFAYPVYV -o ddg.csv
+
+Pass exactly one of ``--alanine-scan`` (one row per position mutated to alanine) or one
+or more ``--mutant`` (neoantigen mode). Both subcommands share the ``--interface``,
+``--regions``, ``-p/--potential`` and ``--cutoff`` options with ``tcren score``.

--- a/docs/tcren.rst
+++ b/docs/tcren.rst
@@ -179,6 +179,14 @@ tcren.pipeline module
    :undoc-members:
    :show-inheritance:
 
+tcren.oracle module
+~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: tcren.oracle
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 tcren.refine package
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/scripts/summarize_structure_example.py
+++ b/scripts/summarize_structure_example.py
@@ -1,0 +1,38 @@
+"""Turn a TCR-pMHC PDB into the five tcren summary tables.
+
+Runs the :func:`tcren.summarize_structure` facade on a structure and writes each of the
+five returned frames to a CSV, demonstrating the one-call entry point the paper notebooks
+use. The default structure is the bundled ``1ao7`` test fixture.
+
+Usage::
+
+    python scripts/summarize_structure_example.py [STRUCTURE.pdb] [OUT_DIR]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from tcren import summarize_structure
+
+_DEFAULT_PDB = Path(__file__).resolve().parents[1] / "tests" / "assets" / "pdb" / "1ao7.pdb"
+
+
+def main() -> None:
+    pdb = Path(sys.argv[1]) if len(sys.argv) > 1 else _DEFAULT_PDB
+    out_dir = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("summary")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # One call composes S1-S4: pipeline scores + markup + contacts, percentile rank, and
+    # the per-position alanine scan. superimpose=False skips canonical orientation here.
+    tables = summarize_structure(pdb, superimpose=False, background=1000, alanine=True)
+
+    for name, frame in tables.items():
+        path = out_dir / f"{name}.csv"
+        frame.write_csv(str(path))
+        print(f"{name:9s} {frame.shape[0]:>4d} x {frame.shape[1]:<2d} -> {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tcren/__init__.py
+++ b/src/tcren/__init__.py
@@ -9,6 +9,7 @@ from . import potential
 from .contactmap import ContactMap
 from .contacts import all_atom_contacts, ca_distance_matrix
 from .ddg import alanine_scan, ddg, neoantigen_ddg
+from .oracle import summarize_structure
 from .pipeline import PipelineResult
 from .pipeline import run as run_pipeline
 from .potential import Potential, derive_tcren, derive_tcren_loo
@@ -37,6 +38,7 @@ __all__ = [
     "ddg",
     "alanine_scan",
     "neoantigen_ddg",
+    "summarize_structure",
     "run_pipeline",
     "PipelineResult",
     "substitute_peptide",

--- a/src/tcren/oracle.py
+++ b/src/tcren/oracle.py
@@ -1,0 +1,142 @@
+"""One-call facade over the tcren pipeline for the paper notebooks.
+
+:func:`summarize_structure` turns a single TCR-pMHC structure into a bundle of
+ready-to-tabulate polars frames by composing the existing milestones:
+
+* **S1+S2** — :func:`tcren.pipeline.run` (annotate → orient → contacts → per-interface
+  scores), giving the ``scores``, ``markup`` and ``contacts`` frames;
+* **S3** — :func:`tcren.scoring_rank.percentile_rank` of the structure's native peptide
+  against a random pMHC background, giving the ``rank`` frame;
+* **S4** — :func:`tcren.ddg.alanine_scan` of the native peptide, giving the ``ddg`` frame.
+
+Nothing is re-derived here: the facade only orchestrates the milestone functions and
+collects their outputs. The ``scores`` frame is therefore byte-identical to what
+``run`` produces for the same structure and arguments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+from .contactmap import ContactMap
+from .ddg import alanine_scan
+from .pipeline import run
+from .potential import Potential
+from .scoring_rank import percentile_rank
+from .structure.io import import_structure
+from .structure.model import PEPTIDE_TYPE, Structure
+
+#: Columns of the ``ddg`` frame (matches :func:`tcren.ddg.alanine_scan`).
+_DDG_SCHEMA = {"pos": pl.Int64, "wt_aa": pl.Utf8, "ddG": pl.Float64}
+
+
+def _native_peptide(structure: Structure) -> str:
+    """Return the one-letter sequence of the structure's peptide chain."""
+    for chain in structure.chains:
+        if chain.chain_type == PEPTIDE_TYPE:
+            return chain.sequence()
+    raise ValueError(f"no peptide chain found in {structure.pdb_id!r}")
+
+
+def summarize_structure(
+    structure: str | Path | Structure,
+    *,
+    organism: str = "human",
+    superimpose: bool = True,
+    potentials: dict[str, str | Potential | None] | None = None,
+    tcr_regions: str = "all",
+    background: int = 1000,
+    seed: int = 0,
+    alanine: bool = False,
+) -> dict[str, pl.DataFrame]:
+    """Summarise one TCR-pMHC structure into a bundle of tables.
+
+    Composes the tcren milestones on a single structure: the full pipeline (S1+S2)
+    for per-interface energies, region markup and contacts; the percentile rank of the
+    native peptide against a random background (S3); and, optionally, the per-position
+    alanine scan (S4).
+
+    Args:
+        structure: A structure file (any tcren-readable format) or a parsed
+            :class:`~tcren.structure.model.Structure`.
+        organism: Organism for TCR annotation.
+        superimpose: Also orient onto the canonical database (adds ``rmsd`` to ``scores``).
+        potentials: Optional per-interface potential override, forwarded to
+            :func:`tcren.pipeline.run`. The TCR↔peptide potential is also used for the
+            ``rank`` and ``ddg`` frames.
+        tcr_regions: Which TCR regions to keep on the TCR side (``"all"`` default,
+            ``"cdr"`` or ``"cdr+fr"``); forwarded to every milestone.
+        background: Number of random background peptides for the percentile rank (S3).
+        seed: Random seed for the background generation.
+        alanine: When ``True``, compute the per-position alanine scan (S4) for the
+            ``ddg`` frame. When ``False`` (default) the scan is skipped and ``ddg`` is an
+            empty frame with the same schema.
+
+    Returns:
+        Mapping with five polars frames:
+
+        * ``scores`` — one row of per-interface energies (and ``rmsd`` if superimposed),
+          identical to :func:`tcren.pipeline.run`'s scores.
+        * ``rank`` — one row: the native peptide's energy and its ``rank_pct`` against the
+          background.
+        * ``ddg`` — the alanine scan (columns ``pos``/``wt_aa``/``ddG``); empty unless
+          ``alanine=True``.
+        * ``markup`` — the per-residue region-markup table.
+        * ``contacts`` — the annotated residue-contact table.
+    """
+    s = structure if isinstance(structure, Structure) else import_structure(structure)
+
+    # S1 + S2: full pipeline (parses nothing extra — reuses the parsed structure and
+    # annotates its chains in place, which is what lets us read the native peptide below).
+    result = run(
+        s,
+        organism=organism,
+        superimpose=superimpose,
+        potentials=potentials,
+        tcr_regions=tcr_regions,
+    )
+    native = _native_peptide(s)
+
+    # The TCR↔peptide potential drives the rank/ddg frames; resolve it exactly as the
+    # pipeline does so an override is honoured consistently across all three frames.
+    tcr_peptide_pot = _resolve_tcr_peptide_potential(potentials)
+
+    cm = ContactMap.from_structure(s)
+
+    scores = pl.DataFrame(
+        {"pdb.id": result.pdb_id, "rmsd": result.rmsd, **result.scores}
+    )
+
+    rank_row = percentile_rank(
+        cm,
+        native,
+        tcr_peptide_pot,
+        n_background=background,
+        seed=seed,
+        tcr_regions=tcr_regions,
+    )
+    rank = pl.DataFrame({"pdb.id": result.pdb_id, **rank_row})
+
+    if alanine:
+        ddg = alanine_scan(cm, native, tcr_peptide_pot, tcr_regions=tcr_regions)
+    else:
+        ddg = pl.DataFrame(schema=_DDG_SCHEMA)
+
+    return {
+        "scores": scores,
+        "rank": rank,
+        "ddg": ddg,
+        "markup": result.markup,
+        "contacts": result.contacts,
+    }
+
+
+def _resolve_tcr_peptide_potential(
+    potentials: dict[str, str | Potential | None] | None,
+) -> Potential:
+    """Resolve the TCR↔peptide potential the same way :func:`tcren.pipeline.run` does."""
+    from .pipeline import _resolve_potentials
+
+    return _resolve_potentials(potentials)["tcr_peptide"]

--- a/tests/unit/test_oracle.py
+++ b/tests/unit/test_oracle.py
@@ -1,0 +1,80 @@
+"""Unit tests for the S5 facade :func:`tcren.summarize_structure`.
+
+The facade only orchestrates S1-S4, so the checks are structural (all five frames
+with the expected columns) plus the byte-exact identity that its ``scores`` frame
+reproduces :func:`tcren.pipeline.run`'s scores under default arguments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("arda")  # facade runs the full pipeline (arda / mmseqs annotation)
+
+from tcren import summarize_structure  # noqa: E402
+from tcren.pipeline import run  # noqa: E402
+from tcren.structure.io import import_structure  # noqa: E402
+
+_FIXTURE = Path(__file__).resolve().parents[1] / "assets" / "pdb" / "1ao7.pdb"
+
+_EXPECTED_COLUMNS = {
+    "scores": ["pdb.id", "rmsd", "tcr_peptide", "tcr_mhc", "peptide_mhc", "total"],
+    "rank": ["pdb.id", "peptide", "score", "rank_pct", "n_background"],
+    "ddg": ["pos", "wt_aa", "ddG"],
+    "markup": [
+        "chain.id", "residue.index", "chain.type", "chain.supertype",
+        "region.type", "region.start", "residue.aa",
+    ],
+}
+
+
+def test_summarize_returns_five_frames_with_expected_columns():
+    out = summarize_structure(_FIXTURE, superimpose=False, background=50)
+    assert set(out) == {"scores", "rank", "ddg", "markup", "contacts"}
+    for key, cols in _EXPECTED_COLUMNS.items():
+        assert out[key].columns == cols, key
+    # one summary row each for scores and rank
+    assert out["scores"].height == 1
+    assert out["rank"].height == 1
+    # markup / contacts are non-empty per-residue / per-contact tables
+    assert out["markup"].height > 0
+    assert out["contacts"].height > 0
+    assert "pdb.id" in out["contacts"].columns
+
+
+def test_ddg_empty_without_alanine_flag():
+    out = summarize_structure(_FIXTURE, superimpose=False, background=50)
+    # default alanine=False -> empty ddg frame, but with the alanine-scan schema
+    assert out["ddg"].height == 0
+    assert out["ddg"].columns == ["pos", "wt_aa", "ddG"]
+
+
+def test_alanine_flag_runs_per_position_scan():
+    out = summarize_structure(_FIXTURE, superimpose=False, background=50, alanine=True)
+    ddg = out["ddg"]
+    # one row per peptide position
+    native = out["rank"]["peptide"][0]
+    assert ddg.height == len(native)
+    assert ddg["wt_aa"].to_list() == list(native)
+
+
+def test_scores_reproduce_run_byte_exact():
+    # Facade scores must equal run()'s scores exactly under matching arguments.
+    out = summarize_structure(_FIXTURE, superimpose=False, background=50)
+    res = run(import_structure(_FIXTURE), superimpose=False)
+    row = out["scores"].to_dicts()[0]
+    assert row["pdb.id"] == res.pdb_id
+    for key in ("tcr_peptide", "tcr_mhc", "peptide_mhc", "total"):
+        assert row[key] == res.scores[key]
+
+
+def test_rank_uses_native_peptide_and_is_deterministic():
+    a = summarize_structure(_FIXTURE, superimpose=False, background=100, seed=0)
+    b = summarize_structure(_FIXTURE, superimpose=False, background=100, seed=0)
+    ra, rb = a["rank"].to_dicts()[0], b["rank"].to_dicts()[0]
+    assert ra == rb  # same seed -> identical rank row
+    assert ra["peptide"] == "LLFGYPVYV"  # the structure's native peptide
+    assert ra["n_background"] == 100
+    assert 0.0 <= ra["rank_pct"] <= 1.0


### PR DESCRIPTION
## S5 — oracle facade

Adds `src/tcren/oracle.py` with the single entry point the paper notebooks call:

```python
summarize_structure(
    structure, *, organism="human", superimpose=True, potentials=None,
    tcr_regions="all", background=1000, seed=0, alanine=False
) -> dict[str, pl.DataFrame]
```

It composes the existing milestones — `run()` (S1+S2), `percentile_rank()` (S3) and `alanine_scan()` (S4) — and returns `{"scores","rank","ddg","markup","contacts"}`. No scoring logic is reimplemented; the facade only orchestrates the milestone functions, so its `scores` frame is byte-identical to `run()`'s.

### Returned frames
| Key | Source | Contents |
|---|---|---|
| `scores` | S1+S2 (`run`) | per-interface energies + `rmsd` (one row) |
| `rank` | S3 (`percentile_rank`) | native peptide energy + `rank_pct` (one row) |
| `ddg` | S4 (`alanine_scan`) | per-position alanine scan; empty unless `alanine=True` |
| `markup` | S1+S2 (`run`) | per-residue region markup |
| `contacts` | S1+S2 (`run`) | annotated residue contacts |

### Changes
- **`__init__.py`**: re-export `summarize_structure` (the other four — `percentile_rank`, `background_peptides`, `ddg`, `alanine_scan`, `neoantigen_ddg` — were already exported).
- **Docs**: new `docs/oracle.rst` (API reference + the `rank`/`ddg` CLI + a `literalinclude`'d script example) wired into `index.rst`; `tcren.oracle` automodule added to `tcren.rst`. Build is clean (zero new warnings).
- **Example**: `scripts/summarize_structure_example.py` turns a PDB into the five summary CSVs.
- **Tests**: `tests/unit/test_oracle.py` — five frames with expected columns, default args reproduce `run()`'s scores byte-exact, the `alanine` flag gates the per-position scan, and `rank` uses the native peptide and is seed-deterministic.

### Verification
- Fast suite: `163 passed, 2 skipped, 34 deselected`.
- Byte-exact scoring regression (`tests/regression/test_score_regression.py`): passes.
- `env -C docs make html`: zero new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)