### PR TITLE
fix(ddg): zero ΔΔG for interfaces without the peptide (tcr_mhc bug)

### DIFF
--- a/src/tcren/ddg.py
+++ b/src/tcren/ddg.py
@@ -17,6 +17,11 @@ from .contactmap import ContactMap, Interface
 from .potential import Potential
 from .scoring import score_peptides
 
+#: Interfaces whose contacts include the peptide. A peptide point mutation can only
+#: change the energy of an interface that the peptide is part of; for any other
+#: interface (e.g. ``"tcr_mhc"``) every per-position ΔΔG is exactly 0.
+_PEPTIDE_INTERFACES: frozenset[str] = frozenset({"tcr_peptide", "peptide_mhc"})
+
 
 def _score_one(
     contact_map: ContactMap,
@@ -59,7 +64,11 @@ def ddg(
 
     Returns:
         ``E(native) - E(mutant)``; positive means the mutation is destabilising.
+        Always ``0.0`` for interfaces that do not contain the peptide (e.g.
+        ``"tcr_mhc"``), since a peptide mutation cannot affect them.
     """
+    if interface not in _PEPTIDE_INTERFACES:
+        return 0.0
     e_native = _score_one(contact_map, native, potential, interface, tcr_regions)
     e_mutant = _score_one(contact_map, mutant, potential, interface, tcr_regions)
     return e_native - e_mutant
@@ -88,14 +97,24 @@ def alanine_scan(
     Returns:
         Columns ``pos`` (0-based), ``wt_aa`` (native residue at that position) and
         ``ddG`` (``E(native) - E(Ala@pos)``). Positions without TCR contacts yield
-        ``ddG == 0.0``.
+        ``ddG == 0.0``. For interfaces that do not contain the peptide (e.g.
+        ``"tcr_mhc"``) every position yields ``ddG == 0.0``.
     """
-    e_native = _score_one(contact_map, native, potential, interface, tcr_regions)
+    peptide_iface = interface in _PEPTIDE_INTERFACES
+    e_native = (
+        _score_one(contact_map, native, potential, interface, tcr_regions)
+        if peptide_iface
+        else 0.0
+    )
     rows = []
     for pos, wt in enumerate(native):
-        mutant = native[:pos] + "A" + native[pos + 1 :]
-        e_mut = _score_one(contact_map, mutant, potential, interface, tcr_regions)
-        rows.append({"pos": pos, "wt_aa": wt, "ddG": e_native - e_mut})
+        if peptide_iface:
+            mutant = native[:pos] + "A" + native[pos + 1 :]
+            e_mut = _score_one(contact_map, mutant, potential, interface, tcr_regions)
+            ddg_val = e_native - e_mut
+        else:
+            ddg_val = 0.0
+        rows.append({"pos": pos, "wt_aa": wt, "ddG": ddg_val})
     return pl.DataFrame(rows, schema={"pos": pl.Int64, "wt_aa": pl.Utf8, "ddG": pl.Float64})
 
 

--- a/tests/unit/test_ddg.py
+++ b/tests/unit/test_ddg.py
@@ -90,6 +90,54 @@ def test_alanine_scan_position_matches_independent_ddg():
         assert scan.filter(pl.col("pos") == pos)["ddG"][0] == pytest.approx(expected)
 
 
+def _toy_tcr_mhc_contact_map() -> ContactMap:
+    # TCR 'A' contacts MHC within-region pos 0; TCR 'L' contacts MHC pos 2.
+    # The peptide is NOT part of this interface, so a peptide mutation must not
+    # change any score. residue.aa.to are MHC residues ('K', 'A'); were the
+    # candidate peptide threaded onto pos.to (the bug), it would substitute these.
+    contacts = pl.DataFrame(
+        {
+            "chain.type.from": ["TRA", "TRB"],
+            "chain.type.to": ["MHCa", "MHCa"],
+            "residue.aa.from": ["A", "L"],
+            "residue.aa.to": ["K", "A"],
+            "region.type.from": ["CDR3", "CDR3"],
+            "residue.index.from": [10, 20],
+            "residue.index.to": [0, 2],
+            "region.start.from": [8, 18],
+            "region.start.to": [0, 0],
+            "pdb.id": ["toy", "toy"],
+        }
+    )
+    return ContactMap(pdb_id="toy", contacts=contacts, peptide_length=3)
+
+
+def test_ddg_tcr_mhc_is_zero():
+    # A peptide mutation cannot affect the TCR-MHC interface (no peptide on it).
+    cm, pot = _toy_tcr_mhc_contact_map(), _toy_potential()
+    assert ddg(cm, "AGK", "AGA", pot, interface="tcr_mhc") == 0.0
+    # Same when the peptide is unchanged.
+    assert ddg(cm, "AGK", "AGK", pot, interface="tcr_mhc") == 0.0
+
+
+def test_alanine_scan_tcr_mhc_all_zero():
+    # Every per-position ΔΔG must be exactly 0 for an interface without the peptide.
+    cm, pot = _toy_tcr_mhc_contact_map(), _toy_potential()
+    native = "AGK"
+    scan = alanine_scan(cm, native, pot, interface="tcr_mhc")
+    assert scan.columns == ["pos", "wt_aa", "ddG"]
+    assert scan.height == len(native)
+    assert scan["pos"].to_list() == [0, 1, 2]
+    assert scan["wt_aa"].to_list() == list(native)
+    assert scan["ddG"].to_list() == [0.0, 0.0, 0.0]
+
+
+def test_neoantigen_ddg_tcr_mhc_all_zero():
+    cm, pot = _toy_tcr_mhc_contact_map(), _toy_potential()
+    df = neoantigen_ddg(cm, "AGK", ["AGA", "KKK"], pot, interface="tcr_mhc")
+    assert df["ddG"].to_list() == [0.0, 0.0]
+
+
 def test_neoantigen_ddg():
     cm, pot = _toy_contact_map(), _toy_potential()
     native = "AGK"


### PR DESCRIPTION
## The bug

`tcren.ddg.alanine_scan(..., interface="tcr_mhc")` (and `ddg`/`neoantigen_ddg` with any interface that does **not** contain the peptide) returned **spurious nonzero ΔΔG**.

**Mechanism:** `alanine_scan` mutates peptide positions, then `score_peptides` (`src/tcren/scoring.py`) threads the candidate peptide string onto the contacted positions of whatever interface is passed. `_PEPTIDE_SIDE["tcr_mhc"] = "to"`, but the `"to"` side of the `tcr_mhc` interface is the **MHC** residue, not the peptide. So the candidate peptide gets substituted onto MHC positions, producing a meaningless value that changes with the candidate.

**Correct behaviour:** a peptide-alanine scan can only change interfaces that *include* the peptide (`tcr_peptide`, `peptide_mhc`); for `tcr_mhc` every per-position ΔΔG must be `0`.

## The fix

Surgical guard in `src/tcren/ddg.py`: short-circuit `ddg` and `alanine_scan` to `0.0` for any interface not in `{tcr_peptide, peptide_mhc}`. `neoantigen_ddg` inherits the fix via `ddg`. The scoring internals are **untouched**, so `tcr_peptide`/`peptide_mhc` behaviour is byte-identical and the regression oracle is unaffected.

## Tests

Added 3 unit tests in `tests/unit/test_ddg.py` using a toy TCR-MHC contact map (MHC residues `K`,`A` on the `to` side that the bug would substitute onto):
- `test_ddg_tcr_mhc_is_zero`
- `test_alanine_scan_tcr_mhc_all_zero`
- `test_neoantigen_ddg_tcr_mhc_all_zero`

These **fail pre-fix** (reproduce the spurious `2.5`/`3.0`) and **pass post-fix**.

## Verification

`conda run -n tcren-nb python -m pytest -m "not slow" -q` → **166 passed, 2 skipped, 35 deselected**. No `tests/regression/*` files were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)